### PR TITLE
tpx3: allow to cancel while reading header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libertem-asi-tpx3"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bincode",
  "crossbeam",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "libertem-dectris"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bincode",
  "bs_sys",

--- a/libertem_asi_tpx3/Cargo.toml
+++ b/libertem_asi_tpx3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem-asi-tpx3"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 readme = "README.md"
 

--- a/libertem_dectris/Cargo.toml
+++ b/libertem_dectris/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem-dectris"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 readme = "README.md"
 


### PR DESCRIPTION
`stream_recv_header` allows to pass in a closure that can, for example, check for control messages. This allows to cancel if the code is currently waiting for a header to be sent. Before, it would just hang in an `EAGAIN` loop.

With this change, the upstream code also needed to be special cased to not reconnect if the acquisition was cancelled.