### PR TITLE
More robust debug output of detector config header

### DIFF
--- a/libertem_dectris/src/receiver.rs
+++ b/libertem_dectris/src/receiver.rs
@@ -227,6 +227,13 @@ fn passive_acquisition(
 
             // second message: the header itself
             recv_part(&mut msg, socket, control_channel)?;
+
+            if let Some(msg_str) = msg.as_str() {
+                debug!("detector config: {}", msg_str);
+            } else {
+                warn!("non-string received as detector config!")
+            }
+
             let detector_config: DetectorConfig =
                 serde_json::from_str(msg.as_str().unwrap()).unwrap();
 
@@ -490,10 +497,15 @@ fn background_thread(
 
                     // second message: the header itself
                     recv_part(&mut msg, &socket, to_thread_r)?;
+
+                    if let Some(msg_str) = msg.as_str() {
+                        debug!("detector config: {}", msg_str);
+                    } else {
+                        warn!("non-string received as detector config!")
+                    }
+
                     let detector_config: DetectorConfig =
                         serde_json::from_str(msg.as_str().unwrap()).unwrap();
-
-                    debug!("detector config: {}", msg.as_str().unwrap());
 
                     match acquisition(
                         detector_config,


### PR DESCRIPTION
Output header before trying to deserialize. This should mean we get much better log messages in case something goes wrong with serialization.