### PR TITLE
Add license file and metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 the LiberTEM developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ code in submodules. After cloning, remember to enable pre-commit hooks using
 - `libertem_asi_tpx3`: A Rust+Python library for receiving sparse array streams from Amsterdam Scientific Instruments CheeTah TPX3 detectors.
 - `libertem_dectris`: This is a Python package for efficiently receiving data from DECTRIS detectors with the zeromq interface.
 - `playegui`: `egui`-based prototype for efficient on-line visualization of 4D STEM reconstructions
+
+
+## License
+
+All crates are made available under the MIT license, if not specified otherwise.

--- a/bs-sys/Cargo.toml
+++ b/bs-sys/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "bs_sys"
+authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
+license = "MIT"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.66"

--- a/ipc_test/Cargo.toml
+++ b/ipc_test/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "ipc-test"
+authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
+license = "MIT"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.66"

--- a/playegui/Cargo.toml
+++ b/playegui/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "playegui"
+authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
+license = "MIT"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.66"

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "stats"
+authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
+license = "MIT"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.66"


### PR DESCRIPTION
The Python modules (TPX3, DECTRIS) already had MIT license in their metadata, but general information for the repository was still missing.

Closes #42