### PR TITLE
Update and consolidate dependencies; test on MSRV/Linux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         crate: [libertem_dectris, libertem_asi_tpx3, libertem_qd_mpx]
-        toolchain: ["stable", "1.66"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -33,7 +32,6 @@ jobs:
         working-directory: ${{ matrix.crate }}
         manylinux: auto
         command: build
-        rust-toolchain: ${{ matrix.toolchain }}
         container: ghcr.io/libertem/manylinux2014_x86_64:latest
         args: --release --sdist -o target/dist --find-interpreter
         sccache: 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         crate: [libertem_dectris, libertem_asi_tpx3, libertem_qd_mpx]
+        toolchain: ["stable", "1.66"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -32,6 +33,7 @@ jobs:
         working-directory: ${{ matrix.crate }}
         manylinux: auto
         command: build
+        rust-toolchain: ${{ matrix.toolchain }}
         container: ghcr.io/libertem/manylinux2014_x86_64:latest
         args: --release --sdist -o target/dist --find-interpreter
         sccache: 'true'
@@ -46,12 +48,13 @@ jobs:
     strategy:
       matrix:
         crate: [libertem_dectris, libertem_asi_tpx3, libertem_asi_mpx3, libertem_qd_mpx, ipc_test, common]
+        toolchain: ["stable", "1.66"]
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: rustup stable
-      run: rustup default stable
+    - name: rustup ${{ matrix.toolchain }}
+      run: rustup default ${{ matrix.toolchain }}
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.7.3
     - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -795,6 +795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,16 +1381,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "env_filter"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1740,7 +1756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc93b03242719b8ad39fb26ed2b01737144ce7bd4bfc7adadcef806596760fe"
 dependencies = [
  "bitflags 1.3.2",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "cgl",
  "core-foundation",
  "dispatch",
@@ -1762,7 +1778,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629a873fc04062830bfe8f97c03773bcd7b371e23bcc465d0a61448cd1588fa4"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -2146,7 +2162,7 @@ dependencies = [
  "log",
  "memfd",
  "memmap2",
- "nix 0.26.4",
+ "nix 0.29.0",
  "page_size",
  "raw_sync",
  "sendfd",
@@ -2282,9 +2298,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libertem-asi-mpx3"
@@ -2343,7 +2359,7 @@ dependencies = [
  "lz4",
  "md5",
  "memmap2",
- "nix 0.26.4",
+ "nix 0.29.0",
  "num",
  "numpy",
  "opentelemetry",
@@ -2439,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lz4"
@@ -2725,7 +2741,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -2736,6 +2751,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -3804,18 +3831,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3824,11 +3851,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -4160,18 +4188,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5185,7 +5213,7 @@ checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-foundation",
  "core-graphics",
  "dispatch",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,10 +13,10 @@ ipc-test = { path = "../ipc_test" }
 stats = { path = "../stats" }
 pyo3 = { version = "0.21.2", features = ["abi3-py37"] }
 numpy = "0.21"
-serde = "1.0.199"
+serde = "1.0.210"
 tempfile = "3.10.1"
-thiserror = "1.0.59"
-log = "0.4.21"
+thiserror = "1.0.64"
+log = "0.4.22"
 ndarray = { version = "0.15.6" }
 zerocopy = "0.7.35"
 num = "0.4.3"

--- a/ipc_test/Cargo.toml
+++ b/ipc_test/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.66"
 
 [dependencies]
 anyhow = "1.0.66"
-thiserror = "1.0.59"
+thiserror = "1.0.64"
 bincode = "1.3.3"
 bytemuck = "1.12.3"
 clap = { version = "4.0.29", features = ["derive"] }
@@ -18,8 +18,8 @@ crossbeam = { version ="0.8.2", features = ["crossbeam-channel"] }
 memmap2 = "0.5.8"
 page_size = "0.5.0"
 raw_sync = "0.1.5"
-serde = { version = "1.0.149", features = ["derive"] }
-log = "0.4.17"
+serde = { version = "1.0.210", features = ["derive"] }
+log = "0.4.22"
 tempfile = "3.3.0"
 shared_memory = "0.12.4"
 
@@ -28,4 +28,4 @@ memfd = "0.6.2"
 sendfd = "0.4.3"
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "0.26.2"
+nix = { version = "0.29.0", features = ["poll"] }

--- a/ipc_test/src/backend_memfd.rs
+++ b/ipc_test/src/backend_memfd.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, Read, Write},
     ops::Deref,
     os::{
-        fd::{AsRawFd, FromRawFd, RawFd},
+        fd::{AsFd, AsRawFd, FromRawFd, RawFd},
         unix::net::{UnixListener, UnixStream},
     },
     path::{Path, PathBuf},
@@ -112,10 +112,10 @@ where
                 Err(err) => {
                     /* EAGAIN / EWOULDBLOCK */
                     if err.kind() == io::ErrorKind::WouldBlock {
-                        let fd = listener.as_raw_fd();
                         let flags = PollFlags::POLLIN;
-                        let pollfd = PollFd::new(fd, flags);
-                        nix::poll::poll(&mut [pollfd], 100).expect("poll for socket to be ready");
+                        let pollfd = PollFd::new(listener.as_fd(), flags);
+                        nix::poll::poll(&mut [pollfd], 100u16)
+                            .expect("poll for socket to be ready");
                         continue;
                     }
                     /* connection failed */

--- a/libertem_asi_mpx3/Cargo.toml
+++ b/libertem_asi_mpx3/Cargo.toml
@@ -14,10 +14,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.3"
-env_logger = "0.9.3"
-log = "0.4.17"
+env_logger = "0.11.5"
+log = "0.4.22"
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 ipc-test = { path = "../ipc_test" }
 serval-client = { path = "../serval-client" }
 stats = { path = "../stats" }
@@ -25,7 +25,7 @@ common = { path = "../common" }
 zerocopy = "0.7.35"
 numpy = "0.21.0"
 num = "0.4.3"
-thiserror = "1.0.61"
+thiserror = "1.0.64"
 opentelemetry = "0.25.0"
 
 [features]

--- a/libertem_asi_tpx3/Cargo.toml
+++ b/libertem_asi_tpx3/Cargo.toml
@@ -16,11 +16,11 @@ crate-type = ["cdylib"]
 bincode = "1.3.3"
 crossbeam = "0.8.2"
 crossbeam-channel = "0.5.6"
-env_logger = "0.9.3"
-log = "0.4.17"
+env_logger = "0.11.5"
+log = "0.4.22"
 numpy = "0.21"
 pyo3 = { version = "0.21", features = ["abi3-py37"] }
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 ipc-test = { path = "../ipc_test" }
 stats = { path = "../stats" }

--- a/libertem_dectris/Cargo.toml
+++ b/libertem_dectris/Cargo.toml
@@ -17,24 +17,24 @@ name = "libertem-dectris-tool"
 path = "src/main.rs"
 
 [dependencies]
-thiserror = "1.0.59"
+thiserror = "1.0.64"
 bincode = "1.3.3"
 bs_sys = { path = "../bs-sys" }
 clap = { version = "3.2.16", features = ["derive"] }
-env_logger = "0.9.3"
-log = "0.4.17"
+env_logger = "0.11.5"
+log = "0.4.22"
 memmap2 = "0.5.6"
 numpy = "0.21"
 pyo3 = { version = "0.21", features = ["abi3-py37"] }
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
 spin_sleep = "1.1.1"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 zmq = { version = "0.10.0", features = [] }
 ipc-test = { path = "../ipc_test" }
 stats = { path = "../stats" }
 common = { path = "../common" }
-nix = "0.26.1"
+nix = "0.29.0"
 lz4 = "1.24.0"
 zerocopy = "0.7.35"
 md5 = "0.7.0"

--- a/libertem_qd_mpx/Cargo.toml
+++ b/libertem_qd_mpx/Cargo.toml
@@ -14,17 +14,17 @@ rust-version = "1.66"
 
 [dependencies]
 bincode = "1.3.3"
-env_logger = "0.9.3"
-log = "0.4.17"
+env_logger = "0.11.5"
+log = "0.4.22"
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 ipc-test = { path = "../ipc_test" }
 stats = { path = "../stats" }
 common = { path = "../common" }
 zerocopy = "0.7.35"
 numpy = "0.21.0"
 num = "0.4.3"
-thiserror = "1.0.61"
+thiserror = "1.0.64"
 encoding_rs = { version = "0.8.34", features = [] }
 itertools = "0.13.0"
 rand = "0.8.5"

--- a/playegui/Cargo.toml
+++ b/playegui/Cargo.toml
@@ -11,10 +11,10 @@ rust-version = "1.66"
 [dependencies]
 egui = "0.22"
 eframe = { version = "0.22", features = ["default_fonts", "glow"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 tracing-subscriber = "0.3"
-serde_json = "1.0.93"
-log = "0.4.17"
+serde_json = "1.0.128"
+log = "0.4.22"
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 ndarray = { version = "0.15.6", features = ["rayon"] }
 bs_sys = { path = "../bs-sys" }

--- a/serval-client/Cargo.toml
+++ b/serval-client/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.11.17", features = ["json", "blocking"] }
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
 url = "2.3.1"

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -9,4 +9,4 @@ rust-version = "1.66"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.17"
+log = "0.4.22"


### PR DESCRIPTION
Run the tests on Linux on both the stable and the 1.66 (MSRV) toolchain.

Updated direct deps:

* thiserror 1.0.64
* log 0.4.22
* env_logger 0.11.5
* serde 1.0.210
* serde_json 1.0.128
* nix 0.29.0