### PR TITLE
IPC: better error handling

### DIFF
--- a/ipc_test/src/common.rs
+++ b/ipc_test/src/common.rs
@@ -1,0 +1,11 @@
+#[derive(thiserror::Error, Debug)]
+pub enum ShmConnectError {
+    #[error("I/O error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("serialization error: {0}")]
+    SerializationError(#[from] bincode::Error),
+
+    #[error("other error: {msg}")]
+    Other { msg: String },
+}

--- a/ipc_test/src/lib.rs
+++ b/ipc_test/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod common;
 pub(crate) mod freestack;
 pub mod slab;
 


### PR DESCRIPTION
Make it less likely to panic in the low-level IPC code; return errors instead.