### PR TITLE
More explicit error handling; bump to v0.2.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "criterion",
@@ -2304,7 +2304,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libertem-asi-mpx3"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "common",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "libertem-asi-tpx3"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "common",
@@ -2341,13 +2341,14 @@ dependencies = [
  "serde",
  "stats",
  "tempfile",
+ "thiserror",
  "uuid",
  "zerocopy",
 ]
 
 [[package]]
 name = "libertem-dectris"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "bs_sys",
@@ -2377,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "libertem_qd_mpx"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "common",
@@ -3900,6 +3901,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "common"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 rust-version = "1.71"
 
@@ -34,3 +34,6 @@ criterion = "0.5.1"
 [[bench]]
 name = "casting"
 harness = false
+
+[lints.rust]
+unused_must_use = "deny"

--- a/common/src/generic_cam_client.rs
+++ b/common/src/generic_cam_client.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
-use ipc_test::{slab::SlabInitError, SharedSlabAllocator};
+use ipc_test::{
+    slab::{ShmError, SlabInitError},
+    SharedSlabAllocator,
+};
 use multiversion::multiversion;
 use ndarray::ArrayViewMut3;
 use num::cast::AsPrimitive;
@@ -17,6 +20,9 @@ pub enum CamClientError {
         handle_path: String,
         error: SlabInitError,
     },
+
+    #[error("failed to access SHM: {0}")]
+    ShmError(#[from] ShmError),
 
     #[error("operation on closed client")]
     Closed,
@@ -166,7 +172,7 @@ where
         M: FrameMeta,
     {
         let shm = self.get_shm_mut()?;
-        handle.free_slot(shm);
+        handle.free_slot(shm)?;
         Ok(())
     }
 

--- a/common/src/py_connection.rs
+++ b/common/src/py_connection.rs
@@ -191,7 +191,9 @@ macro_rules! impl_py_connection {
                     let _trace_guard = span_from_py(py, &format!("{}::close", stringify!($name)))?;
 
                     if let Some(mut conn_impl) = self.conn_impl.take() {
-                        conn_impl.log_shm_stats();
+                        conn_impl
+                            .log_shm_stats()
+                            .map_err(|e| PyConnectionError::new_err(e.to_string()))?;
                         conn_impl.reset_stats();
                         conn_impl.close();
                         Ok(())
@@ -261,7 +263,9 @@ macro_rules! impl_py_connection {
 
                 pub fn log_shm_stats(&self) -> PyResult<()> {
                     let conn_impl = self.get_conn()?;
-                    conn_impl.log_shm_stats();
+                    conn_impl
+                        .log_shm_stats()
+                        .map_err(|e| PyConnectionError::new_err(e.to_string()))?;
                     Ok(())
                 }
             }

--- a/ipc_test/Cargo.toml
+++ b/ipc_test/Cargo.toml
@@ -29,3 +29,6 @@ sendfd = "0.4.3"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.29.0", features = ["poll"] }
+
+[lints.rust]
+unused_must_use = "deny"

--- a/ipc_test/examples/consumer/main.rs
+++ b/ipc_test/examples/consumer/main.rs
@@ -75,13 +75,13 @@ fn main() {
         // some additional "work":
         //std::thread::sleep(Duration::from_micros(1));
 
-        ssa.free_idx(slot_info.slot_idx);
+        ssa.free_idx(slot_info.slot_idx).unwrap();
 
         sum += sum_part.0 as f64;
         bytes_processed += SLOT_SIZE_BYTES;
 
         if t0.elapsed() > Duration::from_secs(1) {
-            let slots_free = ssa.num_slots_free();
+            let slots_free = ssa.num_slots_free().unwrap();
             println!(
                 "idx: {idx:5}, sum: {sum_part}, throughput: {:7.2} MiB/s, slots free: {slots_free}",
                 bytes_processed as f32 / 1024.0 / 1024.0

--- a/ipc_test/examples/producer/main.rs
+++ b/ipc_test/examples/producer/main.rs
@@ -70,7 +70,7 @@ fn handle_connection(
     }
 
     println!("done sending {} items", send_num_items);
-    while ssa.num_slots_free() < ssa.num_slots_total() {
+    while ssa.num_slots_free().unwrap() < ssa.num_slots_total() {
         thread::sleep(Duration::from_millis(100));
     }
     println!("done!")

--- a/ipc_test/src/backend_shm.rs
+++ b/ipc_test/src/backend_shm.rs
@@ -111,7 +111,7 @@ impl SharedMemory {
 impl Drop for SharedMemory {
     fn drop(&mut self) {
         if self.is_owner {
-            remove_file(&self.handle_path).unwrap();
+            let _ = remove_file(&self.handle_path);
         }
     }
 }

--- a/libertem_asi_mpx3/Cargo.toml
+++ b/libertem_asi_mpx3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem-asi-mpx3"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 readme = "README.md"
 rust-version = "1.71"
@@ -33,3 +33,6 @@ extension-module = ["pyo3/extension-module"]
 
 [dev-dependencies]
 tempfile = "3.3.0"
+
+[lints.rust]
+unused_must_use = "deny"

--- a/libertem_asi_tpx3/Cargo.toml
+++ b/libertem_asi_tpx3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem-asi-tpx3"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 readme = "README.md"
 rust-version = "1.71"
@@ -28,9 +28,13 @@ common = { path = "../common" }
 zerocopy = "0.7.35"
 page_size = "0.5.0"
 opentelemetry = "0.25.0"
+thiserror = "1.0.64"
 
 [dev-dependencies]
 tempfile = "3.3.0"
 
 [features]
 extension-module = ["pyo3/extension-module"]
+
+[lints.rust]
+unused_must_use = "deny"

--- a/libertem_asi_tpx3/src/cam_client.rs
+++ b/libertem_asi_tpx3/src/cam_client.rs
@@ -90,7 +90,8 @@ impl CamClient {
     fn done(mut slf: PyRefMut<Self>, handle: &ChunkStackHandle) -> PyResult<()> {
         let slot_idx = handle.slot.slot_idx;
         if let Some(shm) = &mut slf.shm {
-            shm.free_idx(slot_idx);
+            shm.free_idx(slot_idx)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
             Ok(())
         } else {
             Err(PyRuntimeError::new_err(

--- a/libertem_asi_tpx3/src/headers.rs
+++ b/libertem_asi_tpx3/src/headers.rs
@@ -13,10 +13,15 @@ pub enum HeaderTypes {
     AcquisitionEnd { header: AcquisitionEnd },
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum WireFormatError {
+    #[error("unknown header: {id}")]
     UnknownHeader { id: u8 },
+
+    #[error("unknown version")]
     UnknownVersion,
+
+    #[error("serde error: {err}")]
     SerdeError { err: Box<ErrorKind> },
 }
 

--- a/libertem_asi_tpx3/src/stream.rs
+++ b/libertem_asi_tpx3/src/stream.rs
@@ -7,13 +7,22 @@ use crate::{
     headers::{HeaderTypes, WireFormatError},
 };
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum StreamError {
+    #[error("timeout")]
     Timeout,
+
+    #[error("I/O error: {0}")]
     IoError(std::io::Error),
+
+    #[error("EOF")]
     Eof,
-    FormatError(WireFormatError),
-    ControlError(ControlError),
+
+    #[error("format error: {0}")]
+    FormatError(#[from] WireFormatError),
+
+    #[error("control error: {0}")]
+    ControlError(#[from] ControlError),
 }
 
 impl From<std::io::Error> for StreamError {
@@ -22,18 +31,6 @@ impl From<std::io::Error> for StreamError {
             std::io::ErrorKind::TimedOut => StreamError::Timeout,
             _ => StreamError::IoError(value),
         }
-    }
-}
-
-impl From<WireFormatError> for StreamError {
-    fn from(value: WireFormatError) -> Self {
-        Self::FormatError(value)
-    }
-}
-
-impl From<ControlError> for StreamError {
-    fn from(value: ControlError) -> Self {
-        Self::ControlError(value)
     }
 }
 

--- a/libertem_dectris/Cargo.toml
+++ b/libertem_dectris/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem-dectris"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 readme = "README.md"
 rust-version = "1.71"
@@ -46,3 +46,6 @@ extension-module = ["pyo3/extension-module"]
 
 [dev-dependencies]
 tempfile = "3.3.0"
+
+[lints.rust]
+unused_must_use = "deny"

--- a/libertem_dectris/examples/passive_low_level.py
+++ b/libertem_dectris/examples/passive_low_level.py
@@ -41,7 +41,9 @@ def main(width: int, height: int):
                 break
 
             tq.update(len(stack_handle))
-            continue
+            if False:
+                cam_client.done(stack_handle)
+                continue
 
             # the expected shape and data type:
             frame_shape = tuple(reversed(stack_handle.get_shape()))

--- a/libertem_qd_mpx/Cargo.toml
+++ b/libertem_qd_mpx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem_qd_mpx"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 readme = "README.md"
 rust-version = "1.71"
@@ -41,3 +41,6 @@ tokio = { version = "1", features = ["rt", "net", "time", "sync", "io-util", "rt
 [[bench]]
 name = "decoders"
 harness = false
+
+[lints.rust]
+unused_must_use = "deny"

--- a/serval-client/Cargo.toml
+++ b/serval-client/Cargo.toml
@@ -12,4 +12,8 @@ rust-version = "1.71"
 reqwest = { version = "0.11.17", features = ["json", "blocking"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
+thiserror = "1.0.64"
 url = "2.3.1"
+
+[lints.rust]
+unused_must_use = "deny"

--- a/serval-client/src/lib.rs
+++ b/serval-client/src/lib.rs
@@ -1,12 +1,15 @@
-use std::fmt::Display;
-
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use url::Url;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ServalError {
+    #[error("request failed: {msg}")]
     RequestFailed { msg: String },
+
+    #[error("serialization error: {msg}")]
     SerializationError { msg: String },
+
+    #[error("URL error: {msg}")]
     URLError { msg: String },
 }
 
@@ -30,16 +33,6 @@ impl From<reqwest::Error> for ServalError {
     fn from(value: reqwest::Error) -> Self {
         Self::RequestFailed {
             msg: value.to_string(),
-        }
-    }
-}
-
-impl Display for ServalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ServalError::RequestFailed { msg } => write!(f, "request failed: {msg}"),
-            ServalError::SerializationError { msg } => write!(f, "serialization error: {msg}"),
-            ServalError::URLError { msg } => write!(f, "URL error: {msg}"),
         }
     }
 }

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -10,3 +10,6 @@ rust-version = "1.71"
 
 [dependencies]
 log = "0.4.22"
+
+[lints.rust]
+unused_must_use = "deny"


### PR DESCRIPTION
Handle cases where constructing the `Mutex` object can fail, and push the related error through the system. Replace manual `Display` implementations with `thiserror` usage.