### PR TITLE
Add `dynamic=["version"]` where it was missing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,7 @@ jobs:
     strategy:
       matrix:
         crate: [libertem_dectris, libertem_asi_tpx3, libertem_asi_mpx3, libertem_qd_mpx]
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set LIBCLANG_PATH

--- a/libertem_asi_mpx3/pyproject.toml
+++ b/libertem_asi_mpx3/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
 dependencies = [
     "opentelemetry-api",
 ]
+dynamic = ["version"]
 
 [project.urls]
 repository = "https://github.com/LiberTEM/LiberTEM-rs/"

--- a/libertem_asi_tpx3/pyproject.toml
+++ b/libertem_asi_tpx3/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
 dependencies = [
     "opentelemetry-api",
 ]
+dynamic = ["version"]
 
 [project.urls]
 repository = "https://github.com/LiberTEM/LiberTEM-rs/"

--- a/libertem_dectris/pyproject.toml
+++ b/libertem_dectris/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy>=1.16.0",
     "opentelemetry-api",
 ]
+dynamic = ["version"]
 
 [project.urls]
 repository = "https://github.com/LiberTEM/LiberTEM-rs/"


### PR DESCRIPTION
Fixes "`project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list".