### PR TITLE
Update dependencies: pyo3, numpy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -601,7 +601,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 1.0.109",
  "which",
@@ -706,7 +706,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -892,7 +892,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -905,10 +905,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1377,7 +1377,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1641,7 +1641,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1877,6 +1877,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2746,17 +2752,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if 1.0.0",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -2924,14 +2919,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "numpy"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
+checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
 dependencies = [
  "libc",
  "ndarray",
@@ -2939,7 +2934,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
- "rustc-hash",
+ "rustc-hash 2.1.0",
 ]
 
 [[package]]
@@ -3041,7 +3036,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3247,7 +3242,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3422,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -3449,20 +3444,20 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "e484fd2c8b4cb67ab05a318f1fd6fa8f199fcc30819f08f07d200809dba26c15"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -3472,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "dc0e0469a84f208e20044b98965e1561028180219e35352a2afaf2b942beff3b"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3482,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3492,27 +3487,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "fdb6da8ec6fa5cedd1626c886fc8749bdcbb09424a86461eb8cdf096b7c33257"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "38a385202ff5a92791168b1136afae5059d3ac118457bb7bc304c197c2d33e7d"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3577,7 +3572,7 @@ checksum = "2a34bde3561f980a51c70495164200569a11662644fe5af017f0b5d7015688cc"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "nix 0.27.1",
+ "nix 0.29.0",
  "rand",
  "winapi",
 ]
@@ -3706,6 +3701,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
@@ -3847,7 +3848,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3870,7 +3871,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4094,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4143,7 +4144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
 dependencies = [
  "cfg-expr",
- "heck",
+ "heck 0.4.1",
  "pkg-config",
  "toml",
  "version-compare",
@@ -4157,9 +4158,9 @@ checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -4205,7 +4206,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4304,7 +4305,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4480,7 +4481,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4709,7 +4710,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -4743,7 +4744,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5400,7 +5401,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.71"
 bincode = "1.3.3"
 ipc-test = { path = "../ipc_test" }
 stats = { path = "../stats" }
-pyo3 = { version = "0.21.2", features = ["abi3-py37"] }
-numpy = "0.21"
+pyo3 = { version = "0.23", features = ["abi3-py37"] }
+numpy = "0.23"
 serde = "1.0.210"
 tempfile = "3.10.1"
 thiserror = "1.0.64"

--- a/common/src/background_thread.rs
+++ b/common/src/background_thread.rs
@@ -1,7 +1,10 @@
 use std::{
     fmt::Debug,
     io,
-    sync::mpsc::{Receiver, Sender},
+    sync::{
+        mpsc::{Receiver, Sender},
+        Mutex,
+    },
 };
 
 use ipc_test::slab::SlabInitError;
@@ -75,7 +78,7 @@ pub trait BackgroundThread {
 
     fn channel_from_thread(
         &mut self,
-    ) -> &mut Receiver<ReceiverMsg<Self::FrameMetaImpl, Self::AcquisitionConfigImpl>>;
+    ) -> &mut Mutex<Receiver<ReceiverMsg<Self::FrameMetaImpl, Self::AcquisitionConfigImpl>>>;
 
     fn join(self);
 }

--- a/common/src/generic_connection.rs
+++ b/common/src/generic_connection.rs
@@ -238,7 +238,12 @@ where
         &mut self,
         timeout: Duration,
     ) -> Result<ReceiverMsg<B::FrameMetaImpl, B::AcquisitionConfigImpl>, NextTimeoutError> {
-        let msg = self.bg_thread.channel_from_thread().recv_timeout(timeout)?;
+        let msg = self
+            .bg_thread
+            .channel_from_thread()
+            .get_mut()
+            .unwrap()
+            .recv_timeout(timeout)?;
         self.adjust_status(&msg);
         Ok(msg)
     }

--- a/common/src/py_cam_client.rs
+++ b/common/src/py_cam_client.rs
@@ -12,7 +12,7 @@ macro_rules! decode_for_dtype {
         $end_idx: ident,
         $py: ident
     ) => {
-        if $out.dtype().is_equiv_to(&dtype_bound::<$dtype>($py)) {
+        if $out.dtype().is_equiv_to(&dtype::<$dtype>($py)) {
             let out_downcast = $out.downcast::<PyArray3<$dtype>>()?;
             $self.decode_impl($input, out_downcast, $start_idx, $end_idx, $py)?;
             return Ok(());
@@ -46,8 +46,8 @@ macro_rules! impl_py_cam_client {
                 NumCast,
             };
             use numpy::{
-                dtype_bound, Element, PyArray3, PyArrayDescrMethods, PyArrayMethods,
-                PyUntypedArray, PyUntypedArrayMethods,
+                dtype, Element, PyArray3, PyArrayDescrMethods, PyArrayMethods, PyUntypedArray,
+                PyUntypedArrayMethods,
             };
             use pyo3::{create_exception, exceptions::PyException, prelude::*};
             use zerocopy::{AsBytes, FromBytes};

--- a/common/src/py_connection.rs
+++ b/common/src/py_connection.rs
@@ -26,8 +26,8 @@ macro_rules! impl_py_connection {
             use ipc_test::SharedSlabAllocator;
             use num::NumCast;
             use numpy::{
-                dtype_bound, Element, PyArray3, PyArrayDescrMethods, PyArrayMethods,
-                PyUntypedArray, PyUntypedArrayMethods,
+                dtype, Element, PyArray3, PyArrayDescrMethods, PyArrayMethods, PyUntypedArray,
+                PyUntypedArrayMethods,
             };
             use pyo3::{
                 create_exception,
@@ -161,6 +161,7 @@ macro_rules! impl_py_connection {
                     }
                 }
 
+                #[pyo3(signature=(timeout=None))]
                 pub fn wait_for_arm(
                     &mut self,
                     timeout: Option<f32>,
@@ -207,6 +208,7 @@ macro_rules! impl_py_connection {
                     Ok(conn_impl.is_running())
                 }
 
+                #[pyo3(signature=(timeout=None))]
                 pub fn cancel(&mut self, timeout: Option<f32>, py: Python<'_>) -> PyResult<()> {
                     let _trace_guard = span_from_py(py, &format!("{}::cancel", stringify!($name)))?;
                     let conn_impl = self.get_conn_mut()?;
@@ -226,6 +228,7 @@ macro_rules! impl_py_connection {
                     })
                 }
 
+                #[pyo3(signature=(timeout=None))]
                 pub fn start_passive(
                     &mut self,
                     timeout: Option<f32>,
@@ -323,10 +326,8 @@ macro_rules! impl_py_connection {
                 }
 
                 pub fn serialize<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-                    let bytes: Bound<'py, PyBytes> = PyBytes::new_bound(
-                        py,
-                        serialize(self.try_get_inner()?).unwrap().as_slice(),
-                    );
+                    let bytes: Bound<'py, PyBytes> =
+                        PyBytes::new(py, serialize(self.try_get_inner()?).unwrap().as_slice());
                     Ok(bytes.into())
                 }
 

--- a/common/src/tracing.rs
+++ b/common/src/tracing.rs
@@ -74,7 +74,7 @@ pub fn spawn_tracing_thread(service_name: String, otlp_endpoint: String) {
 }
 
 pub fn get_py_span_context(py: Python) -> PyResult<SpanContext> {
-    let span_context_py = PyModule::import_bound(py, "opentelemetry.trace")?
+    let span_context_py = PyModule::import(py, "opentelemetry.trace")?
         .getattr("get_current_span")?
         .call0()?
         .getattr("get_span_context")?

--- a/libertem_asi_mpx3/Cargo.toml
+++ b/libertem_asi_mpx3/Cargo.toml
@@ -16,14 +16,14 @@ crate-type = ["cdylib"]
 bincode = "1.3.3"
 env_logger = "0.11.5"
 log = "0.4.22"
-pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
+pyo3 = { version = "0.23", features = ["abi3-py37"] }
 serde = { version = "1.0.210", features = ["derive"] }
 ipc-test = { path = "../ipc_test" }
 serval-client = { path = "../serval-client" }
 stats = { path = "../stats" }
 common = { path = "../common" }
 zerocopy = "0.7.35"
-numpy = "0.21.0"
+numpy = "0.23"
 num = "0.4.3"
 thiserror = "1.0.64"
 opentelemetry = "0.25.0"

--- a/libertem_asi_mpx3/src/base_types.rs
+++ b/libertem_asi_mpx3/src/base_types.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serval_client::DetectorConfig;
 
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum DType {
     U8,
     U16,

--- a/libertem_asi_tpx3/Cargo.toml
+++ b/libertem_asi_tpx3/Cargo.toml
@@ -18,8 +18,8 @@ crossbeam = "0.8.2"
 crossbeam-channel = "0.5.6"
 env_logger = "0.11.5"
 log = "0.4.22"
-numpy = "0.21"
-pyo3 = { version = "0.21", features = ["abi3-py37"] }
+numpy = "0.23"
+pyo3 = { version = "0.23", features = ["abi3-py37"] }
 serde = { version = "1.0.210", features = ["derive"] }
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 ipc-test = { path = "../ipc_test" }

--- a/libertem_asi_tpx3/src/chunk_stack.rs
+++ b/libertem_asi_tpx3/src/chunk_stack.rs
@@ -434,8 +434,7 @@ impl ChunkStackHandle {
 #[pymethods]
 impl ChunkStackHandle {
     pub fn serialize<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes: Bound<'py, PyBytes> =
-            PyBytes::new_bound(py, serialize(self).unwrap().as_slice());
+        let bytes: Bound<'py, PyBytes> = PyBytes::new(py, serialize(self).unwrap().as_slice());
         Ok(bytes)
     }
 

--- a/libertem_asi_tpx3/src/headers.rs
+++ b/libertem_asi_tpx3/src/headers.rs
@@ -89,7 +89,7 @@ impl HeaderTypes {
 
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[repr(u8)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum DType {
     U1,
     U4,
@@ -138,7 +138,7 @@ impl DType {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum FormatType {
     /// Sorted CSR
     CSR,

--- a/libertem_asi_tpx3/src/main_py.rs
+++ b/libertem_asi_tpx3/src/main_py.rs
@@ -40,7 +40,7 @@ fn libertem_asi_tpx3(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AcquisitionEnd>()?;
     m.add_class::<CamClient>()?;
     m.add_function(wrap_pyfunction!(make_sim_data, &m)?)?;
-    m.add("TimeoutError", py.get_type_bound::<TimeoutError>())?;
+    m.add("TimeoutError", py.get_type::<TimeoutError>())?;
 
     // register_header_module(py, m)?;
 
@@ -205,6 +205,7 @@ impl ASITpx3Connection {
 #[pymethods]
 impl ASITpx3Connection {
     #[new]
+    #[pyo3(signature=(uri,chunks_per_stack,handle_path,num_slots=None,bytes_per_chunk=None,huge=None))]
     fn new(
         uri: &str,
         chunks_per_stack: usize,

--- a/libertem_dectris/Cargo.toml
+++ b/libertem_dectris/Cargo.toml
@@ -24,8 +24,8 @@ clap = { version = "3.2.16", features = ["derive"] }
 env_logger = "0.11.5"
 log = "0.4.22"
 memmap2 = "0.5.6"
-numpy = "0.21"
-pyo3 = { version = "0.21", features = ["abi3-py37"] }
+numpy = "0.23"
+pyo3 = { version = "0.23", features = ["abi3-py37"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 spin_sleep = "1.1.1"

--- a/libertem_dectris/src/base_types.rs
+++ b/libertem_dectris/src/base_types.rs
@@ -69,7 +69,7 @@ impl DHeader {
 
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum TriggerMode {
     #[serde(rename = "exte")]
     EXTE,
@@ -186,7 +186,7 @@ impl DImage {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[pyclass]
+#[pyclass(eq, eq_int)]
 pub enum PixelType {
     #[serde(rename = "uint8")]
     Uint8,

--- a/libertem_qd_mpx/Cargo.toml
+++ b/libertem_qd_mpx/Cargo.toml
@@ -16,13 +16,13 @@ rust-version = "1.71"
 bincode = "1.3.3"
 env_logger = "0.11.5"
 log = "0.4.22"
-pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
+pyo3 = { version = "0.23", features = ["abi3-py37"] }
 serde = { version = "1.0.210", features = ["derive"] }
 ipc-test = { path = "../ipc_test" }
 stats = { path = "../stats" }
 common = { path = "../common" }
 zerocopy = "0.7.35"
-numpy = "0.21.0"
+numpy = "0.23"
 num = "0.4.3"
 thiserror = "1.0.64"
 encoding_rs = { version = "0.8.34", features = [] }

--- a/libertem_qd_mpx/src/main_py.rs
+++ b/libertem_qd_mpx/src/main_py.rs
@@ -3,6 +3,7 @@ use std::{str::FromStr, time::Duration};
 use common::generic_connection::GenericConnection;
 use common::tracing::{span_from_py, tracing_from_env};
 use numpy::PyUntypedArray;
+use pyo3::types::PyModuleMethods;
 use pyo3::{
     exceptions::PyValueError, pyclass, pymethods, pymodule, types::PyModule, Bound, PyResult,
     Python,
@@ -52,6 +53,10 @@ struct QdConnection {
 impl QdConnection {
     #[new]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature=(
+        data_host,data_port,frame_stack_size,shm_handle_path,drain=None,
+        num_slots=None,bytes_per_frame=None,huge=None,recovery_strategy=None,
+    ))]
     fn new(
         data_host: &str,
         data_port: usize,
@@ -111,6 +116,7 @@ impl QdConnection {
         Ok(QdConnection { conn })
     }
 
+    #[pyo3(signature=(timeout=None))]
     fn wait_for_arm(
         &mut self,
         timeout: Option<f32>,
@@ -127,6 +133,7 @@ impl QdConnection {
         self.conn.is_running()
     }
 
+    #[pyo3(signature=(timeout=None))]
     fn start_passive(&mut self, timeout: Option<f32>, py: Python<'_>) -> PyResult<()> {
         self.conn.start_passive(timeout, py)
     }


### PR DESCRIPTION
Both are not at 0.23.x. Changes needed for this:

- Remove unused CamClient::get_frames from mpx3 lib; don't spend time on transitioning it to the new API
- Put the some non-`Sync` objects into mutexes, to ensure thread safety when used with Python. Mainly the `from_thread` `Receiver` part of the backgroud thread mechanism
- `*_bound` functions are now the default, so move over to the non-deprecated names