### PR TITLE
Bump supported Python version to 3.9+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.74"
 debug = true
 
 [workspace.dependencies]
-pyo3 = { version = "0.27", features = ["abi3-py37"] }
+pyo3 = { version = "0.27.2", features = ["abi3-py39"] }
 numpy = "0.27.1"
 thiserror = "2.0.17"
 tempfile = "3.10.1"

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ come with Python bindings using PyO3, and can be built using [maturin](https://g
 The repository is structured as a cargo workspace, and some of the crates are just used internally,
 like `bs-sys`.
 
-Minimum supported rust version (MSRV) is 1.74 (November 2023)
+Minimum supported rust version (MSRV) is 1.74 (November 2023).
+Minimum Python version supported is 3.9.
 
 ## Development
 
 Please clone using `git clone --recurse-submodules ...` to include vendored
-code in submodules. After cloning, remember to enable pre-commit hooks using
-`pre-commit install --install-hooks`.
+code in submodules. After cloning, remember to enable pre-commit hooks, for example
+using `uvx pre-commit install --install-hooks`.
 
 ## Contents
 

--- a/libertem_asi_mpx3/pyproject.toml
+++ b/libertem_asi_mpx3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "libertem-asi-mpx3"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/libertem_asi_tpx3/pyproject.toml
+++ b/libertem_asi_tpx3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "libertem-asi-tpx3"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/libertem_dectris/pyproject.toml
+++ b/libertem_dectris/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "libertem-dectris"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/libertem_qd_mpx/pyproject.toml
+++ b/libertem_qd_mpx/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "libertem_qd_mpx"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
We don't test on older versions, and even Python 3.9 is already EOL, so this should be sensible.